### PR TITLE
Init dbkey before is used for setting sequence_id

### DIFF
--- a/data_manager/data_manager_fetch_gff.py
+++ b/data_manager/data_manager_fetch_gff.py
@@ -39,7 +39,7 @@ def stop_err(msg):
 
 
 def get_dbkey_dbname_id_name( params, dbkey_description=None ):
-#    dbkey = params['param_dict']['dbkey_source']['dbkey']
+    dbkey = params['param_dict']['dbkey']
     #TODO: ensure sequence_id is unique and does not already appear in location file
     sequence_id = params['param_dict']['sequence_id']
     if not sequence_id:
@@ -50,8 +50,7 @@ def get_dbkey_dbname_id_name( params, dbkey_description=None ):
 #        if not dbkey_name:
 #            dbkey_name = dbkey
 #    else:
-#        dbkey_name = None
-    dbkey = params['param_dict']['dbkey'] 
+#        dbkey_name = None 
     dbkey_name = dbkey_description
     sequence_name = params['param_dict']['sequence_name']
     if not sequence_name:


### PR DESCRIPTION
Currently when sequence_id is not set, it tries to use dbkey, however that variable is only set afterwards. This fixes that. Otherwise, you get:

```
Traceback (most recent call last):
  File "/nfs/public/rw/homes/fg_atlas/galaxy-lsf/shed_tools/toolshed.g2.bx.psu.edu/repos/ieguinoa/data_manager_fetch_gff/4b10131cb66d/data_manager_fetch_gff/data_manager/data_manager_fetch_gff.py", line 288, in <module>
    main()
  File "/nfs/public/rw/homes/fg_atlas/galaxy-lsf/shed_tools/toolshed.g2.bx.psu.edu/repos/ieguinoa/data_manager_fetch_gff/4b10131cb66d/data_manager_fetch_gff/data_manager/data_manager_fetch_gff.py", line 272, in main
    dbkey, dbkey_name, sequence_id, sequence_name = get_dbkey_dbname_id_name( params, dbkey_description=options.dbkey_description ) 
  File "/nfs/public/rw/homes/fg_atlas/galaxy-lsf/shed_tools/toolshed.g2.bx.psu.edu/repos/ieguinoa/data_manager_fetch_gff/4b10131cb66d/data_manager_fetch_gff/data_manager/data_manager_fetch_gff.py", line 46, in get_dbkey_dbname_id_name
    sequence_id = dbkey #uuid.uuid4() generate and use an uuid instead?
UnboundLocalError: local variable 'dbkey' referenced before assignment
```